### PR TITLE
Fix 0x21 0x0A "buffer overflow"

### DIFF
--- a/src/driver/driver.rs
+++ b/src/driver/driver.rs
@@ -157,7 +157,7 @@ impl WebDriver {
                                 let pos = self.source_map.get(&self.idx).unwrap();
                                 let (line, start, end) = get_err_pos(&self.lh, *pos);
                                 return Err(JsValue::from(format!(
-                                    "Error at line {} : {}, value of AH = {} is not supported for int 0x10",
+                                    "Error at line {} : {}, value of AH = {} is not supported for int 0x21",
                                     line,
                                     &self.input[start..end],
                                     ah

--- a/src/driver/driver.rs
+++ b/src/driver/driver.rs
@@ -264,6 +264,9 @@ impl WebDriver {
             for i in ip.bytes() {
                 self.vm.mem[start + 2 + ctr] = i;
                 ctr += 1;
+                if ctr == required {
+                    break;
+                }
             }
         }
     }


### PR DESCRIPTION
Hello it's me again

While trying INTs available, I discovered a "buffer overflow" on the 0x21 0x0A:
* the number of characters read is correct: less than or equal to the maximum allowed
* but all the charecters inputed are put in memory regardless the maximum allowed
```asm
DB 0x44 ; lower border

buffer: 
DB 0x08 ; maximum characters buffer can hold
DB 0X00 ; number of chars readed
DW 0xFFFF ; padding
DW 0xFFFF ; padding
DW 0xFFFF ; padding
DW 0xFFFF ; padding

DB 0x55 ; upper border

; 44 | 08 | 00 | ff | ff | ff | ff | ff | ff | ff | ff | 55

start:
; http://spike.scu.edu.au/~barry/interrupts.html
; DOS 0x21 0x0A
; Buffered Keyboard Input
mov dx, OFFSET buffer
mov ah, 0x0A
int 0x21

; input 1234567890
; expected
; 44 | 08 | 08 | 31 | 32 | 33 | 34 | 35 | 36 | 37 | 38 | 55 | 00
; got
; 44 | 08 | 08 | 31 | 32 | 33 | 34 | 35 | 36 | 37 | 38 | 39 | 30
```

I think there is the same issue on the CLI version:

```rust
interrupts.rs
...
        // store the characters
        for (ctr, i) in input.bytes().enumerate() {
            vm.mem[start + 2 + ctr] = i;
        }
```